### PR TITLE
Quick and dirty support for folder notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+# QUICK 'N DIRTY SUPPORT FOR NOTE FILES
+- when looking for files, I am also allowing folders that are actually folder-notes
+  - simply adjusting the path for those
+- I dont think this is properly supported:
+  - added just few of lines at file: `folderv.tsx`
+  - I don't even know that JS variant is that I'm writing..
+  - descriptions/tags, or custom titles from H1's:
+    - probably OK, as the foldernote path is used (ie `FOO/FOO.md`)
+    - but I don't use these anyway (I hide them afterwards w/ CSS and presenting a list)
+  - custom filtering could also be an issue
+
 # 1.0.0 (2022-02-18)
 
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+# 
+
+---
+
 # AidenLx's Folder Note - `folderv` Component
 
 [Check main repo for details](https://github.com/aidenlx/alx-folder-note)

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
-  "id": "alx-folder-note-folderv",
-  "name": "AidenLx's Folder Note - folderv component",
+  "id": "folderv-dev",
+  "name": "AidenLx's - folderv-dev component",
   "version": "1.0.0",
   "minAppVersion": "0.12.5",
   "description": "Optional `folderv` Component for alx-folder-note",

--- a/manifest.json
+++ b/manifest.json
@@ -1,5 +1,5 @@
 {
-  "id": "folderv-dev",
+  "id": "alx-folderv-dev",
   "name": "AidenLx's - folderv-dev component",
   "version": "1.0.0",
   "minAppVersion": "0.12.5",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "folderv-dev",
+  "name": "alx-folderv-dev",
   "version": "1.0.1",
   "description": "Optional `folderv` Component for alx-folder-note",
   "main": "",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "alx-folder-note-folderv",
-  "version": "1.0.0",
+  "name": "folderv-dev",
+  "version": "1.0.1",
   "description": "Optional `folderv` Component for alx-folder-note",
   "main": "",
   "scripts": {

--- a/src/fv-main.ts
+++ b/src/fv-main.ts
@@ -69,13 +69,15 @@ export default class Folderv extends Plugin {
     console.log("loading alx-folder-note-folderv");
 
     await this.loadSettings();
+
     this.registerMarkdownCodeBlockProcessor(
       FOLDERV_ID,
       GetFolderVHandler(this),
     );
-    if (!this.app.plugins.plugins["alx-folder-note"]) {
+    // CHECK: due to renaming, I'm forcing this plugin to have it's own name
+    // if (!this.app.plugins.plugins["alx-folder-note"]) {
       this.addSettingTab(this.settingTab);
-    }
+    // }
   }
 
   // onunload() {


### PR DESCRIPTION
# QUICK 'N DIRTY SUPPORT FOR NOTE FILES
- when looking for files, I am also allowing folders that are actually folder-notes
  - simply adjusting the path for those
- I dont think this is properly supported:
  - added just few of lines at file: `folderv.tsx`
  - I don't even know that JS variant is that I'm writing..
  - descriptions/tags, or custom titles from H1's:
    - probably OK, as the foldernote path is used (ie `FOO/FOO.md`)
    - but I don't use these anyway (I hide them afterwards w/ CSS and presenting a list)
  - custom filtering could also be an issue
